### PR TITLE
修复log实体类在异步组装过程中request参数获取失败的情况等问题

### DIFF
--- a/blade-core-log/src/main/java/org/springblade/core/log/event/ApiLogListener.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/event/ApiLogListener.java
@@ -22,16 +22,13 @@ import org.springblade.core.launch.props.BladeProperties;
 import org.springblade.core.launch.server.ServerInfo;
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.feign.ILogClient;
+import org.springblade.core.log.model.LogAbstract;
 import org.springblade.core.log.model.LogApi;
-import org.springblade.core.secure.utils.SecureUtil;
-import org.springblade.core.tool.utils.UrlUtil;
-import org.springblade.core.tool.utils.WebUtil;
+import org.springblade.core.log.utils.LogAbstractUtil;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
 
-import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
 import java.util.Map;
 
 
@@ -55,18 +52,7 @@ public class ApiLogListener {
 	public void saveApiLog(ApiLogEvent event) {
 		Map<String, Object> source = (Map<String, Object>) event.getSource();
 		LogApi logApi = (LogApi) source.get(EventConstant.EVENT_LOG);
-		HttpServletRequest request = (HttpServletRequest) source.get(EventConstant.EVENT_REQUEST);
-		logApi.setServiceId(bladeProperties.getName());
-		logApi.setServerHost(serverInfo.getHostName());
-		logApi.setServerIp(serverInfo.getIpWithPort());
-		logApi.setEnv(bladeProperties.getEnv());
-		logApi.setRemoteIp(WebUtil.getIP(request));
-		logApi.setUserAgent(request.getHeader(WebUtil.USER_AGENT_HEADER));
-		logApi.setRequestUri(UrlUtil.getPath(request.getRequestURI()));
-		logApi.setMethod(request.getMethod());
-		logApi.setParams(WebUtil.getRequestParamString(request));
-		logApi.setCreateBy(SecureUtil.getUserAccount(request));
-		logApi.setCreateTime(LocalDateTime.now());
+		LogAbstractUtil.addOtherInfoToLog(logApi, bladeProperties, serverInfo);
 		logService.saveApiLog(logApi);
 	}
 

--- a/blade-core-log/src/main/java/org/springblade/core/log/event/ErrorLogListener.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/event/ErrorLogListener.java
@@ -22,15 +22,13 @@ import org.springblade.core.launch.props.BladeProperties;
 import org.springblade.core.launch.server.ServerInfo;
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.feign.ILogClient;
+import org.springblade.core.log.model.LogAbstract;
 import org.springblade.core.log.model.LogError;
-import org.springblade.core.secure.utils.SecureUtil;
-import org.springblade.core.tool.utils.WebUtil;
+import org.springblade.core.log.utils.LogAbstractUtil;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
 
-import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
 import java.util.Map;
 
 /**
@@ -52,16 +50,7 @@ public class ErrorLogListener {
 	public void saveErrorLog(ErrorLogEvent event) {
 		Map<String, Object> source = (Map<String, Object>) event.getSource();
 		LogError logError = (LogError) source.get(EventConstant.EVENT_LOG);
-		HttpServletRequest request = (HttpServletRequest) source.get(EventConstant.EVENT_REQUEST);
-		logError.setUserAgent(request.getHeader(WebUtil.USER_AGENT_HEADER));
-		logError.setMethod(request.getMethod());
-		logError.setParams(WebUtil.getRequestParamString(request));
-		logError.setServiceId(bladeProperties.getName());
-		logError.setServerHost(serverInfo.getHostName());
-		logError.setServerIp(serverInfo.getIpWithPort());
-		logError.setEnv(bladeProperties.getEnv());
-		logError.setCreateBy(SecureUtil.getUserAccount(request));
-		logError.setCreateTime(LocalDateTime.now());
+		LogAbstractUtil.addOtherInfoToLog(logError, bladeProperties, serverInfo);
 		logService.saveErrorLog(logError);
 	}
 

--- a/blade-core-log/src/main/java/org/springblade/core/log/event/UsualLogListener.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/event/UsualLogListener.java
@@ -22,16 +22,13 @@ import org.springblade.core.launch.props.BladeProperties;
 import org.springblade.core.launch.server.ServerInfo;
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.feign.ILogClient;
+import org.springblade.core.log.model.LogAbstract;
 import org.springblade.core.log.model.LogUsual;
-import org.springblade.core.secure.utils.SecureUtil;
-import org.springblade.core.tool.utils.UrlUtil;
-import org.springblade.core.tool.utils.WebUtil;
+import org.springblade.core.log.utils.LogAbstractUtil;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
 
-import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
 import java.util.Map;
 
 /**
@@ -53,17 +50,7 @@ public class UsualLogListener {
 	public void saveUsualLog(UsualLogEvent event) {
 		Map<String, Object> source = (Map<String, Object>) event.getSource();
 		LogUsual logUsual = (LogUsual) source.get(EventConstant.EVENT_LOG);
-		HttpServletRequest request = (HttpServletRequest) source.get(EventConstant.EVENT_REQUEST);
-		logUsual.setRequestUri(UrlUtil.getPath(request.getRequestURI()));
-		logUsual.setUserAgent(request.getHeader(WebUtil.USER_AGENT_HEADER));
-		logUsual.setMethod(request.getMethod());
-		logUsual.setParams(WebUtil.getRequestParamString(request));
-		logUsual.setServerHost(serverInfo.getHostName());
-		logUsual.setServiceId(bladeProperties.getName());
-		logUsual.setEnv(bladeProperties.getEnv());
-		logUsual.setServerIp(serverInfo.getIpWithPort());
-		logUsual.setCreateBy(SecureUtil.getUserAccount(request));
-		logUsual.setCreateTime(LocalDateTime.now());
+		LogAbstractUtil.addOtherInfoToLog(logUsual, bladeProperties, serverInfo);
 		logService.saveUsualLog(logUsual);
 	}
 

--- a/blade-core-log/src/main/java/org/springblade/core/log/feign/ILogClient.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/feign/ILogClient.java
@@ -16,6 +16,7 @@
 package org.springblade.core.log.feign;
 
 import org.springblade.core.launch.constant.AppConstant;
+import org.springblade.core.log.feign.fallback.ILogClientHystric;
 import org.springblade.core.log.model.LogApi;
 import org.springblade.core.log.model.LogUsual;
 import org.springblade.core.log.model.LogError;
@@ -30,7 +31,8 @@ import org.springframework.web.bind.annotation.RequestBody;
  * @author Chill
  */
 @FeignClient(
-	value = AppConstant.APPLICATION_LOG_NAME
+	value = AppConstant.APPLICATION_LOG_NAME,
+	fallback = ILogClientHystric.class
 )
 public interface ILogClient {
 

--- a/blade-core-log/src/main/java/org/springblade/core/log/feign/fallback/ILogClientHystric.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/feign/fallback/ILogClientHystric.java
@@ -1,0 +1,38 @@
+package org.springblade.core.log.feign.fallback;
+
+import com.alibaba.fastjson.JSON;
+import lombok.extern.slf4j.Slf4j;
+import org.springblade.core.log.feign.ILogClient;
+import org.springblade.core.log.model.LogApi;
+import org.springblade.core.log.model.LogError;
+import org.springblade.core.log.model.LogUsual;
+import org.springblade.core.tool.api.R;
+import org.springframework.stereotype.Component;
+
+/**
+ * @Auther: jiang
+ * @Date: 2019/04/26 23:04
+ */
+@Component
+@Slf4j
+public class ILogClientHystric implements ILogClient {
+
+	@Override
+	public R<Boolean> saveUsualLog(LogUsual log) {
+		//注：这里如果使用log.toString()来打印日志的话，只能打印出该对象自身的属性值，无法输出父类的属性值
+		this.log.error("usual log send fail:{}", JSON.toJSONString(log));
+		return R.fail("usual log send fail");
+	}
+
+	@Override
+	public R<Boolean> saveApiLog(LogApi log) {
+		this.log.error("api log send fail:{}", JSON.toJSONString(log));
+		return R.fail("api log send fail");
+	}
+
+	@Override
+	public R<Boolean> saveErrorLog(LogError log) {
+		this.log.error("error log send fail:{}", JSON.toJSONString(log));
+		return R.fail("error log send fail");
+	}
+}

--- a/blade-core-log/src/main/java/org/springblade/core/log/model/LogAbstract.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/model/LogAbstract.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2018-2028, Chill Zhuang 庄骞 (smallchill@163.com).
+ * <p>
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE 3.0;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springblade.core.log.model;
+
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+import org.springblade.core.launch.props.BladeProperties;
+import org.springblade.core.launch.server.ServerInfo;
+import org.springblade.core.secure.utils.SecureUtil;
+import org.springblade.core.tool.utils.DateUtil;
+import org.springblade.core.tool.utils.StringPool;
+import org.springblade.core.tool.utils.UrlUtil;
+import org.springblade.core.tool.utils.WebUtil;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * logApi、logError、logUsual的父类，拥有相同的属性值
+ * @Auther: jiang
+ * @Date: 2019/04/26 23:00
+ */
+@Data
+public class LogAbstract implements Serializable {
+
+	protected static final long serialVersionUID = 1L;
+
+	/**
+	 * 主键id
+	 */
+	@TableId(value = "id", type = IdType.ID_WORKER)
+	protected Long id;
+
+	/**
+	 * 服务ID
+	 */
+	protected String serviceId;
+	/**
+	 * 服务器 ip
+	 */
+	protected String serverIp;
+	/**
+	 * 服务器名
+	 */
+	protected String serverHost;
+	/**
+	 * 环境
+	 */
+	protected String env;
+	/**
+	 * 操作IP地址
+	 */
+	protected String remoteIp;
+	/**
+	 * 用户代理
+	 */
+	protected String userAgent;
+	/**
+	 * 请求URI
+	 */
+	protected String requestUri;
+	/**
+	 * 操作方式
+	 */
+	protected String method;
+	/**
+	 * 方法类
+	 */
+	protected String methodClass;
+	/**
+	 * 方法名
+	 */
+	protected String methodName;
+	/**
+	 * 操作提交的数据
+	 */
+	protected String params;
+	/**
+	 * 执行时间
+	 */
+	protected String time;
+
+	/**
+	 * 创建人
+	 */
+	protected String createBy;
+
+	/**
+	 * 创建时间
+	 */
+	@DateTimeFormat(pattern = DateUtil.PATTERN_DATETIME)
+	@JsonFormat(pattern = DateUtil.PATTERN_DATETIME)
+	protected LocalDateTime createTime;
+
+}

--- a/blade-core-log/src/main/java/org/springblade/core/log/model/LogApi.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/model/LogApi.java
@@ -16,16 +16,10 @@
 package org.springblade.core.log.model;
 
 
-import com.baomidou.mybatisplus.annotation.IdType;
-import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
-import org.springblade.core.tool.utils.DateUtil;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 /**
  * 实体类
@@ -34,15 +28,9 @@ import java.time.LocalDateTime;
  */
 @Data
 @TableName("blade_log_api")
-public class LogApi implements Serializable {
+public class LogApi extends LogAbstract implements Serializable {
 
 	private static final long serialVersionUID = 1L;
-
-	/**
-	 * 主键id
-	 */
-	@TableId(value = "id", type = IdType.ID_WORKER)
-	private Long id;
 
 	/**
 	 * 日志类型
@@ -52,66 +40,5 @@ public class LogApi implements Serializable {
 	 * 日志标题
 	 */
 	private String title;
-	/**
-	 * 服务ID
-	 */
-	private String serviceId;
-	/**
-	 * 服务器 ip
-	 */
-	private String serverIp;
-	/**
-	 * 服务器名
-	 */
-	private String serverHost;
-	/**
-	 * 环境
-	 */
-	private String env;
-	/**
-	 * 操作IP地址
-	 */
-	private String remoteIp;
-	/**
-	 * 用户代理
-	 */
-	private String userAgent;
-	/**
-	 * 请求URI
-	 */
-	private String requestUri;
-	/**
-	 * 操作方式
-	 */
-	private String method;
-	/**
-	 * 方法类
-	 */
-	private String methodClass;
-	/**
-	 * 方法名
-	 */
-	private String methodName;
-	/**
-	 * 操作提交的数据
-	 */
-	private String params;
-	/**
-	 * 执行时间
-	 */
-	private String time;
-
-	/**
-	 * 创建人
-	 */
-	private String createBy;
-
-	/**
-	 * 创建时间
-	 */
-	@DateTimeFormat(pattern = DateUtil.PATTERN_DATETIME)
-	@JsonFormat(pattern = DateUtil.PATTERN_DATETIME)
-	private LocalDateTime createTime;
-
 
 }

--- a/blade-core-log/src/main/java/org/springblade/core/log/model/LogError.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/model/LogError.java
@@ -16,17 +16,10 @@
 package org.springblade.core.log.model;
 
 
-import com.baomidou.mybatisplus.annotation.IdType;
-import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
-import org.springblade.core.tool.utils.DateUtil;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.lang.Nullable;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 /**
  * 服务 异常
@@ -35,44 +28,10 @@ import java.time.LocalDateTime;
  */
 @Data
 @TableName("blade_log_error")
-public class LogError implements Serializable {
+public class LogError extends LogAbstract implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * 主键id
-	 */
-	@TableId(value = "id", type = IdType.ID_WORKER)
-	private Long id;
-	/**
-	 * 应用名
-	 */
-	private String serviceId;
-	/**
-	 * 环境
-	 */
-	private String env;
-	/**
-	 * 服务器 ip
-	 */
-	private String serverIp;
-	/**
-	 * 服务器名
-	 */
-	private String serverHost;
-	/**
-	 * 用户代理
-	 */
-	private String userAgent;
-	/**
-	 * 请求url
-	 */
-	@Nullable
-	private String requestUri;
-	/**
-	 * 操作方式
-	 */
-	private String method;
 	/**
 	 * 堆栈信息
 	 */
@@ -85,36 +44,16 @@ public class LogError implements Serializable {
 	 * 异常消息
 	 */
 	private String message;
-	/**
-	 * 类名
-	 */
-	private String methodClass;
+
 	/**
 	 * 文件名
 	 */
 	private String fileName;
-	/**
-	 * 方法名
-	 */
-	private String methodName;
-	/**
-	 * 操作提交的数据
-	 */
-	private String params;
+
 	/**
 	 * 代码行数
 	 */
 	private Integer lineNumber;
 
-	/**
-	 * 创建人
-	 */
-	private String createBy;
 
-	/**
-	 * 创建时间
-	 */
-	@DateTimeFormat(pattern = DateUtil.PATTERN_DATETIME)
-	@JsonFormat(pattern = DateUtil.PATTERN_DATETIME)
-	private LocalDateTime createTime;
 }

--- a/blade-core-log/src/main/java/org/springblade/core/log/model/LogUsual.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/model/LogUsual.java
@@ -16,16 +16,10 @@
 package org.springblade.core.log.model;
 
 
-import com.baomidou.mybatisplus.annotation.IdType;
-import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
-import org.springblade.core.tool.utils.DateUtil;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 /**
  * 实体类
@@ -35,31 +29,10 @@ import java.time.LocalDateTime;
  */
 @Data
 @TableName("blade_log_usual")
-public class LogUsual implements Serializable {
+public class LogUsual extends LogAbstract implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * 主键id
-	 */
-	@TableId(value = "id", type = IdType.ID_WORKER)
-	private Long id;
-	/**
-	 * 服务ID
-	 */
-	private String serviceId;
-	/**
-	 * 服务器名
-	 */
-	private String serverHost;
-	/**
-	 * 服务器IP地址
-	 */
-	private String serverIp;
-	/**
-	 * 系统环境
-	 */
-	private String env;
 	/**
 	 * 日志级别
 	 */
@@ -72,32 +45,6 @@ public class LogUsual implements Serializable {
 	 * 日志数据
 	 */
 	private String logData;
-	/**
-	 * 操作方式
-	 */
-	private String method;
-	/**
-	 * 请求URI
-	 */
-	private String requestUri;
-	/**
-	 * 用户代理
-	 */
-	private String userAgent;
-	/**
-	 * 操作提交的数据
-	 */
-	private String params;
-	/**
-	 * 创建者
-	 */
-	private String createBy;
-	/**
-	 * 创建时间
-	 */
-	@DateTimeFormat(pattern = DateUtil.PATTERN_DATETIME)
-	@JsonFormat(pattern = DateUtil.PATTERN_DATETIME)
-	private LocalDateTime createTime;
 
 
 }

--- a/blade-core-log/src/main/java/org/springblade/core/log/publisher/ApiLogPublisher.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/publisher/ApiLogPublisher.java
@@ -16,13 +16,17 @@
 
 package org.springblade.core.log.publisher;
 
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springblade.core.log.annotation.ApiLog;
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.event.ApiLogEvent;
+import org.springblade.core.log.model.LogAbstract;
+import org.springblade.core.log.model.LogApi;
+import org.springblade.core.log.utils.LogAbstractUtil;
 import org.springblade.core.tool.constant.BladeConstant;
 import org.springblade.core.tool.utils.SpringUtil;
 import org.springblade.core.tool.utils.WebUtil;
-import org.springblade.core.log.model.LogApi;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -43,9 +47,10 @@ public class ApiLogPublisher {
 		logApi.setTime(String.valueOf(time));
 		logApi.setMethodClass(methodClass);
 		logApi.setMethodName(methodName);
+
+		LogAbstractUtil.addRequestInfoToLog(request, logApi);
 		Map<String, Object> event = new HashMap<>(16);
 		event.put(EventConstant.EVENT_LOG, logApi);
-		event.put(EventConstant.EVENT_REQUEST, request);
 		SpringUtil.publishEvent(new ApiLogEvent(event));
 	}
 

--- a/blade-core-log/src/main/java/org/springblade/core/log/publisher/ErrorLogPublisher.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/publisher/ErrorLogPublisher.java
@@ -18,8 +18,13 @@ package org.springblade.core.log.publisher;
 
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.event.ErrorLogEvent;
-import org.springblade.core.tool.utils.*;
+import org.springblade.core.log.model.LogAbstract;
 import org.springblade.core.log.model.LogError;
+import org.springblade.core.log.utils.LogAbstractUtil;
+import org.springblade.core.tool.utils.Exceptions;
+import org.springblade.core.tool.utils.Func;
+import org.springblade.core.tool.utils.SpringUtil;
+import org.springblade.core.tool.utils.WebUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -49,6 +54,8 @@ public class ErrorLogPublisher {
 				logError.setLineNumber(element.getLineNumber());
 			}
 		}
+		LogAbstractUtil.addRequestInfoToLog(request, logError);
+
 		Map<String, Object> event = new HashMap<>(16);
 		event.put(EventConstant.EVENT_LOG, logError);
 		event.put(EventConstant.EVENT_REQUEST, request);

--- a/blade-core-log/src/main/java/org/springblade/core/log/publisher/UsualLogPublisher.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/publisher/UsualLogPublisher.java
@@ -18,9 +18,11 @@ package org.springblade.core.log.publisher;
 
 import org.springblade.core.log.constant.EventConstant;
 import org.springblade.core.log.event.UsualLogEvent;
+import org.springblade.core.log.model.LogAbstract;
+import org.springblade.core.log.model.LogUsual;
+import org.springblade.core.log.utils.LogAbstractUtil;
 import org.springblade.core.tool.utils.SpringUtil;
 import org.springblade.core.tool.utils.WebUtil;
-import org.springblade.core.log.model.LogUsual;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -39,6 +41,8 @@ public class UsualLogPublisher {
 		logUsual.setLogLevel(level);
 		logUsual.setLogId(id);
 		logUsual.setLogData(data);
+
+		LogAbstractUtil.addRequestInfoToLog(request, logUsual);
 		Map<String, Object> event = new HashMap<>(16);
 		event.put(EventConstant.EVENT_LOG, logUsual);
 		event.put(EventConstant.EVENT_REQUEST, request);

--- a/blade-core-log/src/main/java/org/springblade/core/log/utils/LogAbstractUtil.java
+++ b/blade-core-log/src/main/java/org/springblade/core/log/utils/LogAbstractUtil.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2019-2029, DreamLu 卢春梦 (596392912@qq.com & www.dreamlu.net).
+ * <p>
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE 3.0;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springblade.core.log.utils;
+
+import org.springblade.core.launch.props.BladeProperties;
+import org.springblade.core.launch.server.ServerInfo;
+import org.springblade.core.log.model.LogAbstract;
+import org.springblade.core.secure.utils.SecureUtil;
+import org.springblade.core.tool.utils.StringPool;
+import org.springblade.core.tool.utils.UrlUtil;
+import org.springblade.core.tool.utils.WebUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.ServerSocket;
+import java.net.UnknownHostException;
+import java.time.LocalDateTime;
+import java.util.Enumeration;
+
+/**
+ * INet 相关工具
+ *
+ * @author L.cm
+ */
+public class LogAbstractUtil {
+
+	/**
+	 * 向log中添加补齐request的信息
+	 * @param request
+	 * @param logAbstract
+	 */
+	public static void addRequestInfoToLog(HttpServletRequest request, LogAbstract logAbstract) {
+		logAbstract.setRemoteIp(WebUtil.getIP(request));
+		logAbstract.setUserAgent(request.getHeader(WebUtil.USER_AGENT_HEADER));
+		logAbstract.setRequestUri(UrlUtil.getPath(request.getRequestURI()));
+		logAbstract.setMethod(request.getMethod());
+		logAbstract.setParams(WebUtil.getRequestParamString(request));
+		logAbstract.setCreateBy(SecureUtil.getUserAccount(request));
+	}
+
+	/**
+	 * 向log中添加补齐其他的信息（eg：blade、server等）
+	 * @param logAbstract
+	 * @param bladeProperties
+	 * @param serverInfo
+	 */
+	public static void addOtherInfoToLog(LogAbstract logAbstract, BladeProperties bladeProperties, ServerInfo serverInfo) {
+		logAbstract.setServiceId(bladeProperties.getName());
+		logAbstract.setServerHost(serverInfo.getHostName());
+		logAbstract.setServerIp(serverInfo.getIpWithPort());
+		logAbstract.setEnv(bladeProperties.getEnv());
+		logAbstract.setCreateTime(LocalDateTime.now());
+
+		//这里判断一下params为null的情况，否则blade-log服务在解析该字段的时候，可能会报出NPE
+		if(logAbstract.getParams() == null){
+			logAbstract.setParams(StringPool.EMPTY);
+		}
+	}
+}


### PR DESCRIPTION
1、 修复可能产生的，在日志event事件中，http请求已返回，从而异步处理request时，其参数为null的情况
2、剥离出通用log属性模块类LogAbstarct，同时创建了对应的工具类LogAbstractUtil;
3、添加IlogClient进行http请求失败后的降级fallback，并打印日志（解决日志发送失败，而本地又没有对应日志记录的情况）